### PR TITLE
feat(backend, frontend): add rough skeleton support for file uploads

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,4 +3,5 @@ dist
 .tmp
 .sass-cache
 public/components
+uploads
 .DS_Store

--- a/backend/app/app.js
+++ b/backend/app/app.js
@@ -6,6 +6,7 @@ var logger = require('morgan');
 var bodyParser = require('body-parser');
 var errorHandler = require('errorhandler');
 var cors = require('cors');
+var multer  = require('multer');
 
 var conf = require('../config');
 var middlewares = require('./middlewares');
@@ -23,12 +24,14 @@ api.use(cors(conf.corsOptions));
 api.use(favicon(path.join(__dirname, '/public/icons/favicon.ico')));
 api.use(logger('dev'));
 api.use(bodyParser.json());
+api.use(multer({ dest: path.join(__dirname,'/uploads/')}));
 if (process.env.NODE_ENV === 'development') {
   api.use(errorHandler());
 }
 
 // Routes
 api.get('/', controllers.getMeta);
+api.post('/upload', controllers.uploadFile);
 api.get('/basket/candies', controllers.getCandies);
 api.get('/basket/candies/tags', controllers.getTags);
 api.get('/basket/candies/tags-by-candies', controllers.getTagsByCandies);

--- a/backend/app/controllers.js
+++ b/backend/app/controllers.js
@@ -11,6 +11,7 @@
  */
 
 var async = require('async');
+var fs = require('fs');
 var nano = require('nano');
 var validator = require('validator');
 var sanitizer = require('sanitizer');
@@ -342,6 +343,28 @@ var getTagsByCandies = function(req, res) {
  
 };
 
+/**
+ * @description
+ * 
+ * A function to asynchronously handle file uploads. Currently, it
+ * stores the files on the filesystem automatically. Eventually it
+ * should upload the files to an ownCloud shared folder. The
+ * filesystem is straight forward and thus used in order to try and
+ * get the file uploading from the Angular frontend working.
+ * 
+ * When the time comes, uploading to the cloud will be handled here.
+ * And even further down the line it could be useful to directly
+ * stream the files to the cloud completely by-passing the filesystem
+ * to optimize both space and time.
+ */
+var uploadFile = function(req, res) {
+
+  console.log('files: ', req.files);
+  res.send(200, {'name': req.files.file.name, 
+                 'originalName': req.files.file.originalname});
+
+};
+
 var serve404 = function(req, res) {
   res.send(404);
 };
@@ -359,4 +382,5 @@ exports.deleteCandy = deleteCandy;
 exports.getCandies = getCandies;
 exports.getTags = getTags;
 exports.getTagsByCandies = getTagsByCandies;
+exports.uploadFile = uploadFile;
 exports.serve404 = serve404;

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "express": "~4.2.0",
     "iz": "^0.5.1",
     "morgan": "~1.1.1",
+    "multer": "^0.1.4",
     "nano": "^5.10.0",
     "sanitizer": "^0.1.2",
     "serve-favicon": "~2.0.1",

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -100,6 +100,7 @@
     <script src="bower_components/angular-ui-slider/src/slider.js"></script>
     <script src="bower_components/angular-timelinejs/build/angular-timelinejs.js"></script>
     <script src="bower_components/angular-ui-tinymce/src/tinymce.js"></script>
+    <script src="bower_components/angular-file-upload/angular-file-upload.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/frontend/app/scripts/app.js
+++ b/frontend/app/scripts/app.js
@@ -20,7 +20,8 @@ angular
     /* Third party modules */
     'ui.bootstrap', 
     'ui.tinymce', 
-    'ui.slider', 
+    'ui.slider',
+    'angularFileUpload',
     /* Our own reusable modules */
     'pippTimelineDirectives'
   ])

--- a/frontend/app/styles/styles.css
+++ b/frontend/app/styles/styles.css
@@ -305,3 +305,18 @@ input.ng-valid.ng-dirty {
   color: #333333;
   margin-top: 2px;  
 }
+
+/* file upload styles */
+
+.my-drop-zone { 
+  border: dotted 3px lightgray; 
+}
+
+ /* Default class applied to drop zones on over */
+.nv-file-over { 
+  border: dotted 3px red; 
+}
+
+.another-file-over-class { 
+  border: dotted 3px green; 
+}

--- a/frontend/app/views/candy-save-modal.html
+++ b/frontend/app/views/candy-save-modal.html
@@ -23,6 +23,95 @@
             </div>
 	  </div>
 	</div>
+
+	<div class="form-group">
+	  <label class="col-md-2 control-label" for="inputFile">File:</label>
+	  <div class="col-md-10">
+            <div class="input-group">
+
+              <div ng-show="uploader.isHTML5">
+                <div nv-file-drop="" uploader="uploader">
+                  <div nv-file-over="" uploader="uploader" over-class="another-file-over-class" class="well my-drop-zone">
+                    Drop zone
+                  </div>
+                </div>
+              </div>
+
+              <div ng-hide="uploader.isHTML5">
+                <input class="form-control" name="file" type="file" 
+                       nv-file-select="" uploader="uploader" />
+              </div>
+
+              <div class="row">
+
+                <div class="col-md-12">
+                  <em>Upload queue</em>
+                  <table class="table">
+                    <thead>
+                      <tr>
+                        <th width="50%">Name</th>
+                        <th ng-show="uploader.isHTML5">Size</th>
+                        <th ng-show="uploader.isHTML5">Progress</th>
+                        <th>Status</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr ng-repeat="item in uploader.queue">
+                        <td><strong>{{ item.file.name }}</strong></td>
+                        <td ng-show="uploader.isHTML5" nowrap>{{ item.file.size/1024/1024|number:2 }} MB</td>
+                        <td ng-show="uploader.isHTML5">
+                          <div class="progress" style="margin-bottom: 0;">
+                            <div class="progress-bar" role="progressbar" ng-style="{ 'width': item.progress + '%' }"></div>
+                          </div>
+                        </td>
+                        <td class="text-center">
+                          <span ng-show="item.isSuccess"><i class="glyphicon glyphicon-ok"></i></span>
+                          <span ng-show="item.isCancel"><i class="glyphicon glyphicon-ban-circle"></i></span>
+                          <span ng-show="item.isError"><i class="glyphicon glyphicon-remove"></i></span>
+                        </td>
+                        <td nowrap>
+                          <button type="button" class="btn btn-success btn-xs" ng-click="item.upload()" ng-disabled="item.isReady || item.isUploading || item.isSuccess">
+                            <span class="glyphicon glyphicon-upload"></span> Upload
+                          </button>
+                          <br />
+                          <button type="button" class="btn btn-warning btn-xs" ng-click="item.cancel()" ng-disabled="!item.isUploading">
+                            <span class="glyphicon glyphicon-ban-circle"></span> Cancel
+                          </button>
+                          <br />
+                          <button type="button" class="btn btn-danger btn-xs" ng-click="item.remove()">
+                            <span class="glyphicon glyphicon-trash"></span> Remove
+                          </button>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <div class="col-md-12">
+                  <em>Queue progress</em>
+                  <div class="progress" style="">
+                    <div class="progress-bar" role="progressbar" ng-style="{ 'width': uploader.progress + '%' }"></div>
+                  </div>
+                  <button type="button" class="btn btn-success btn-s" ng-click="uploader.uploadAll()" ng-disabled="!uploader.getNotUploadedItems().length">
+                    <span class="glyphicon glyphicon-upload"></span> Upload all
+                  </button>
+                  <button type="button" class="btn btn-warning btn-s" ng-click="uploader.cancelAll()" ng-disabled="!uploader.isUploading">
+                    <span class="glyphicon glyphicon-ban-circle"></span> Cancel all
+                  </button>
+                  <button type="button" class="btn btn-danger btn-s" ng-click="uploader.clearQueue()" ng-disabled="!uploader.queue.length">
+                    <span class="glyphicon glyphicon-trash"></span> Remove all
+                  </button>
+                </div>
+
+              </div> <!-- end of row -->
+
+              <!-- <input class="form-control" type="file" id="inputFile"
+	      ng-model="candy.file" /> -->
+            </div>
+	  </div>
+	</div>
+
 	<div class="form-group">
 	  <label class="col-md-2 control-label" for="inputTitle">Title:</label>
 	  <div class="col-md-10">

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -21,7 +21,8 @@
     "d3-cloud": "~1.0.5",
     "angular-ui-slider": "~0.0.2",
     "angular-timelinejs": "git@github.com:ghachey/angular-timelinejs.git#master",
-    "angular-ui-tinymce": "git@github.com:angular-ui/ui-tinymce.git#master"
+    "angular-ui-tinymce": "git@github.com:angular-ui/ui-tinymce.git#master",
+    "angular-file-upload": "~1.1.1"
   },
   "devDependencies": {
     "angular-mocks": "1.2.16",
@@ -30,6 +31,7 @@
   "appPath": "app",
   "resolutions": {
     "angular": "1.2.16",
-    "jquery-ui": "~1.11.1"
+    "jquery-ui": "~1.11.1",
+    "es5-shim": ">=3.4.0"
   }
 }


### PR DESCRIPTION
  File upload skeleton includes:
- Add backend endpoint for file uploads
- File uploads save to filesystem currently
- Install angular-file-upload module
- Drag an drop zone in candy save modal
- Queue display below drop zone with file upload operations buttons
- File meta data are added to candy resource and saved to CouchDB
