### PR TITLE
fix(styles): progress bars display problem

### DIFF
--- a/frontend/app/styles/styles.css
+++ b/frontend/app/styles/styles.css
@@ -334,3 +334,8 @@ input.ng-valid.ng-dirty {
   margin-left: -40px;
   list-style: none;
 }
+
+/* Needed to properly display progress bars (override bootstraps's min */
+.progress-bar[aria-valuenow="0"] {
+  min-width: 0px;
+}

--- a/frontend/app/views/candy-list-timeline.html
+++ b/frontend/app/views/candy-list-timeline.html
@@ -55,8 +55,8 @@
 
   <div class="col-md-6">
     <div class="slider" 
-				 tooltip-html-unsafe="{{sliderRange|dateRangeFormatter}}"
-				 tooltip-placement="bottom"
+	 tooltip-html-unsafe="{{sliderRange|dateRangeFormatter}}"
+	 tooltip-placement="bottom"
          ui-slider="slider.options"
          min="{{sliderMin}}"
          max="{{sliderMax}}"


### PR DESCRIPTION
The upgrade to bootstrap 3 added a min-width to bar divs causing a
displaying problem when ever challenge was 0 or very small value.
Overriding the min-width of bars fix this problem.

Closes #17
