### PR TITLE
fix(frontend): fix and enhance candy modal tags input box

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -122,6 +122,7 @@
     <script src="scripts/directives/display-percentages.js"></script>
     <script src="scripts/filters/date-range-formatter.js"></script>
     <script src="scripts/filters/candies-by-dates.js"></script>
+    <script src="scripts/directives/has-tags.js"></script>
     <!-- endbuild -->
 
 </body>

--- a/frontend/app/scripts/directives/has-tags.js
+++ b/frontend/app/scripts/directives/has-tags.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name nasaraCandyBasketApp.directive:hasTags
+ * @description 
+ *
+ * A custom validation directive to verify the Candy modal form has
+ * tags before submitting. This custom validation directive is a
+ * little hackish but mostly because the taglist directive is. The
+ * problem is that the validation works on the *input* field but the
+ * taglist is an input plus a formatted list of tags in a custom html
+ * box. So we can check for validity on each input but this will not
+ * detect whether there are already tags or not. This is why the
+ * broadcast on the tagData model of the taglist directive was setup
+ * and we are listening on it here for changes (to see if it has been
+ * emptied by the user).
+ */
+angular.module('nasaraCandyBasketApp')
+  .directive('hasTags', function($timeout) {
+    return {
+      restrict: 'A',
+      require: 'ngModel',
+      link: function postLink(scope, element, attrs, ctrl) {
+        var valid;
+        var candy = scope.$parent.candy;
+
+        // Listen for changes on tagData model
+        scope.$on('tagDataChanged', function () {
+          if (candy.tags.length === 0) {ctrl.$setValidity('hasTags', false);}
+        });
+
+        // Initial check if tags are empty
+        if (candy.tags === undefined) {ctrl.$setValidity('hasTags', false);}
+
+        // add a parser that will process each time the value is 
+        // parsed into the model when the user updates it.
+        ctrl.$parsers.unshift(function(value) {
+          // There is no current need in processing this live
+          return value;
+        });
+        
+        // add a formatter that will process each time the value 
+        // is updated on the DOM element.
+        ctrl.$formatters.unshift(function(value) {
+
+          if (value) {
+            ctrl.$setValidity('hasTags', true);
+          } else {
+            ctrl.$setValidity('hasTags', false);
+          }
+
+          // Timeout here to wait for candy data to arrive. Hum, I
+          // wish I could have done this nicer but it will do for now
+          $timeout(function(){
+            valid = (candy.tags === undefined) ? false : candy.tags.length !== 0;
+            ctrl.$setValidity('hasTags', valid);
+          }, 500);
+
+          // return the value or nothing will be written to the DOM.
+          return value;
+        });
+
+      }
+    };
+  });

--- a/frontend/app/scripts/directives/taglist.js
+++ b/frontend/app/scripts/directives/taglist.js
@@ -3,15 +3,23 @@
 /**
  * @ngdoc directive
  * @name nasaraCandyBasketApp.directive:taglist
- * @description
- * # taglist
+ * @description 
+ *
  * This directive started based on the work of Chris Pittman
- * https://github.com/chrispittman/angular-taglist
- * but is quickly diverging to fit our needs. If may be worth packaging
- * into its own module and available as bower angular package for others.
+ * https://github.com/chrispittman/angular-taglist but is quickly
+ * diverging to fit our needs. If may be worth packaging into its own
+ * module and available as bower angular package for others or look at
+ * the development of various community directives with similar
+ * features. We may eventually find something better designed and
+ * benefit from contributing to a community driven project.
+ * 
+ * Note on the broadcast on tagDataChanged with this directive. It was
+ * a hackish way to get the custom tags input validation working. It
+ * was mostly working but could not detect when a previously non-empty
+ * tag lists would be completely emptied by the user. Now it can 
  */
 angular.module('nasaraCandyBasketApp')
-  .directive('taglist', function () {
+  .directive('taglist', function ($rootScope) {
     return {
       restrict: 'EA',
       replace: true,
@@ -32,64 +40,58 @@ angular.module('nasaraCandyBasketApp')
         '<div class="tag-input" ng-transclude></div>' + 
         '<div class="tags_clear"></div>' + 
       '</div>',
-      compile: function (tElement, tAttrs) {
+      link: function postLink(scope, element) {
+        
+	// element[0] is <div class="taglist">...</div>
+	// <input...>...</input> element
+        var input = angular.element(element[0]
+                                    .getElementsByTagName('div')[0]
+                                    .getElementsByTagName('input')[0]);
 
-        console.debug('Directive element and attributes: ', tElement, tAttrs);
-
-        return function (scope, element, attrs) {
-
-          console.debug('Scope, element and attributes: ', scope, element, attrs);
-	  // element[0] is <div class="taglist">...</div>
-
-	  // <input...>...</input> element
-          var input = angular.element(element[0]
-                                      .getElementsByTagName('div')[0]
-                                      .getElementsByTagName('input')[0]);
-
-	  // transforming template
-          element.bind('click', function () {
-            element[0].getElementsByTagName('input')[0].focus();
-          });
+	// transforming template
+        element.bind('click', function () {
+          element[0].getElementsByTagName('input')[0].focus();
+        });
 
 
-          input.bind('keydown', function (e) {
+        input.bind('keydown', function (e) {
 
-	    if (e.altKey || e.metaKey ||
-	        e.ctrlKey || e.shiftKey) {
-              return;
-	    }
+	  if (e.altKey || e.metaKey ||
+	      e.ctrlKey || e.shiftKey) {
+            return;
+	  }
 
-	    if (e.which === 188 || e.which === 13) {
-	      // 188 = comma, 13 = return
-              e.preventDefault();
-              addTag(this);
-	    } else if (e.which === 8 && 
-                       this.value.trim().length === 0 && 
-                       element[0].getElementsByClassName('tag').length > 0) {
-              e.preventDefault();
-              scope.$apply(function () {
-	        scope.tagData.splice(scope.tagData.length - 1, 1);
-              });
-	    }
-          });
-
-          function addTag(element) {
-            if (!scope.tagData) {
-              scope.tagData = [];
-            }
-            var val = element.value.trim();
-            if (val.length === 0) {
-              return;
-            }
-            if (scope.tagData.indexOf(val) >= 0) {
-              return;
-            }
+	  if (e.which === 188 || e.which === 13) {
+	    // 188 = comma, 13 = return
+            e.preventDefault();
+            addTag(this);
+	  } else if (e.which === 8 && 
+                     this.value.trim().length === 0 && 
+                     element[0].getElementsByClassName('tag').length > 0) {
+            e.preventDefault();
             scope.$apply(function () {
-              scope.tagData.push(val);
-              element.value = '';
+	      scope.tagData.splice(scope.tagData.length - 1, 1);
+              $rootScope.$broadcast('tagDataChanged',scope.tagData);
             });
+	  }
+        });
+
+        function addTag(element) {
+          if (!scope.tagData) {
+            scope.tagData = [];
           }
-        };
+          var val = element.value.trim();
+          if (val.length === 0) {
+            return;
+          }
+          if (scope.tagData.indexOf(val) >= 0) {
+            return;
+          }
+          scope.$apply(function () {
+            scope.tagData.push(val);
+            element.value = '';
+          });
+        }
 
       }
     };

--- a/frontend/app/styles/main.css
+++ b/frontend/app/styles/main.css
@@ -346,12 +346,16 @@ input.ng-valid.ng-dirty {
 
 /* angular-taglist-directive custom styles */
 
+.form-control-custom {
+  border:4px solid #CCC;   
+}
+
 div.taglist { 
   border:1px solid #CCC; 
-  border-radius: 6px;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
   background: #FFF; 
-  padding: 1em;
-  width: 60%; 
+  padding: 10px 5px 10px 10px;
   border: 1px solid #cccccc;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -405,17 +409,20 @@ div.taglist span.tag a {
 
 div.taglist div.tag-input input { 
   width:120px; 
-  margin:0px; 
+  margin: 0px 0px 0px 5px; 
   font-family: sans-serif; 
   font-size: 13px; 
-  border:1px solid transparent;
+  border:0px solid transparent;
   padding:5px; 
   background: transparent; 
   color: #000; 
   outline:0px;
-  margin-right:5px; 
-  margin-bottom:0px; 
 } 
+
+.taglist-in-modal {
+  width: 100%; 
+}
+
 
 .tags_clear { 
   clear: both;

--- a/frontend/app/views/candy-save-modal.html
+++ b/frontend/app/views/candy-save-modal.html
@@ -4,22 +4,22 @@
       <h3>{{operation}} source</h3>
     </div>
     <div class="modal-body">
-      <form class="form-horizontal" name="candyform" novalidate="novalidate" role="form">
+      <form class="form-horizontal" name="candyform" novalidate role="form">
 	<div class="form-group">
 	  <label class="col-md-2 control-label" for="inputSource">Source:</label>
 	  <div class="col-md-10">
             <div class="input-group">
-	      <input class="form-control" type="url" id="inputSource" name="source"
+	      <input class="form-control" type="url" id="inputSource" name="cSource"
 		     ng-model="candy.source" required />
-	      <div class="input-group-addon" ng-show="candyform.source.$invalid || (candyform.source.$dirty && candyform.source.$invalid)">
-                <span class="required" ng-show="candyform.source.$invalid || candyform.source.$error.required">✗</span>
+	      <div class="input-group-addon" ng-show="candyform.cSource.$invalid || (candyform.cSource.$dirty && candyform.cSource.$invalid)">
+                <span class="required" ng-show="candyform.cSource.$invalid || candyform.cSource.$error.required">✗</span>
               </div>
-	      <div class="input-group-addon ok" ng-show="candyform.source.$valid">
+	      <div class="input-group-addon ok" ng-show="candyform.cSource.$valid">
                 ✔
               </div>
             </div>
-	    <div ng-show="candyform.source.$dirty && candyform.source.$invalid">
-              <span class="help-block error" ng-show="candyform.source.$error.url">Not a valid url</span>
+	    <div ng-show="candyform.cSource.$dirty && candyform.cSource.$invalid">
+              <span class="help-block error" ng-show="candyform.cSource.$error.url">Not a valid url</span>
             </div>
 	  </div>
 	</div>
@@ -128,12 +128,12 @@
 	  <label class="col-md-2 control-label" for="inputTitle">Title:</label>
 	  <div class="col-md-10">
             <div class="input-group">
-	      <input class="form-control" type="text" id="inputTitle" name="title"
+	      <input class="form-control" type="text" id="inputTitle" name="cTitle"
 		     ng-model="candy.title" required/>
-	      <div class="input-group-addon" ng-show="candyform.title.$invalid">
-                <span class="required" ng-show="candyform.title.$error.required">✗</span>
+	      <div class="input-group-addon" ng-show="candyform.cTitle.$invalid">
+                <span class="required" ng-show="candyform.cTitle.$error.required">✗</span>
 	      </div>
-	      <div class="input-group-addon ok" ng-show="candyform.title.$valid">
+	      <div class="input-group-addon ok" ng-show="candyform.cTitle.$valid">
                 ✔
               </div>
             </div>
@@ -143,13 +143,13 @@
 	  <label class="col-md-2 control-label" for="inputDescription">Description:</label>
 	  <div class="col-md-10">
             <div class="input-group">
-	      <textarea ui-tinymce="tinymceOptions" name="description" rows="8" style="width: 80%;" id="inputDescription"
+	      <textarea ui-tinymce="tinymceOptions" name="cDescription" rows="8" style="width: 80%;" id="inputDescription"
 		        ng-model="candy.description" required></textarea>
 	      <div>{{tinymce}}</div>
-	      <div class="input-group-addon" ng-show="candyform.description.$invalid">
-                <span class="required" ng-show="candyform.description.$error.required">✗</span>
+	      <div class="input-group-addon" ng-show="candyform.cDescription.$invalid">
+                <span class="required" ng-show="candyform.cDescription.$error.required">✗</span>
 	      </div>
-	      <div class="input-group-addon ok" ng-show="candyform.description.$valid">
+	      <div class="input-group-addon ok" ng-show="candyform.cDescription.$valid">
                 ✔
               </div>
             </div>
@@ -158,10 +158,16 @@
 	<div class="form-group">
 	  <label class="col-md-2 control-label" for="inputTags">Tags:</label>
 	  <div class="col-md-10">
-            <div class="input-group">
-	      <taglist tag-data="candy.tags" taglist-blur-timeout="250" required>
-       	        <input class="form-control" ng-model="selected1" typeahead="tag for tag in tagsData.tags | filter:$viewValue"/>
+            <div class="input-group taglist-in-modal">
+	      <taglist tag-data="candy.tags" taglist-blur-timeout="250">
+       	        <input class="form-control" name="cTags" ng-model="selected1" type="text" typeahead="tag for tag in tagsData.tags | filter:$viewValue" has-tags />
 	      </taglist>
+	      <div class="input-group-addon" ng-show="candyform.cTags.$invalid">
+                <span class="required" ng-show="candyform.cTags.$error.hasTags">✗</span>
+	      </div>
+	      <div class="input-group-addon ok" ng-show="candyform.cTags.$valid">
+                ✔
+              </div>
             </div>
 	  </div>
 	</div>
@@ -178,6 +184,7 @@
       </div>
 
       <button class="btn btn-primary" title="Save this candy"
+              ng-disabled="candyform.$invalid"
 	      ng-click="saveCandy()">Save</button>
       <button class="btn btn-default"
 	      ng-click="cancel()">Cancel</button>

--- a/frontend/test/spec/directives/has-tags.js
+++ b/frontend/test/spec/directives/has-tags.js
@@ -1,0 +1,61 @@
+'use strict';
+
+describe('Directive: hasTags', function () {
+
+  // load the directive's module
+  beforeEach(module('nasaraCandyBasketApp'));
+
+  var form,
+      scope,
+      $timeout;
+
+  beforeEach(inject(function ($rootScope, $compile, _$timeout_) {
+    var element = angular.element(
+      '<form name="form">' +
+        '<input ng-model="newtags" name="theTags" has-tags />' +
+      '</form>'
+    );
+    var candy = {_id: '12345', tags: ['existingtag']};
+    scope = $rootScope.$new();
+    scope.$parent.candy = candy;
+    scope.newtags = undefined;
+    $compile(element)(scope);
+    scope.$digest();
+    form = scope.form;
+    $timeout = _$timeout_;
+  }));
+
+  it('should pass with non empty list of tags', function () {
+    form.theTags.$setViewValue(['tag1','tag2']);
+    scope.$digest();
+    $timeout.flush();
+    expect(scope.newtags).toEqual(['tag1','tag2']);
+    expect(form.theTags.$valid).toBe(true);
+  });
+
+  it('should not pass with no previous tags', function () {
+    scope.$parent.candy.tags = undefined;
+    expect(form.theTags.$valid).toBe(false);
+  });
+
+  it('should pass with previously no tags but new tags added', function () {
+    scope.$parent.candy.tags = undefined;
+    form.theTags.$setViewValue(['tag3','tag4']);
+    // hack to simulate binding of $parent.candy.tags with the new tags
+    scope.$parent.candy.tags = scope.newtags;
+    scope.$digest();
+    $timeout.flush();
+    expect(scope.newtags).toEqual(['tag3','tag4']);
+    expect(form.theTags.$valid).toBe(true);
+  });
+
+  it('should not pass with empty list of tags on $parent.candy', function () {
+    scope.$parent.candy.tags = [];
+    scope.$digest();
+    $timeout.flush();
+    expect(scope.newstags).toEqual(undefined);
+    expect(form.theTags.$valid).toBe(false);
+  });
+
+
+});

--- a/frontend/test/spec/filters/candies-after-date.js
+++ b/frontend/test/spec/filters/candies-after-date.js
@@ -110,7 +110,7 @@ describe('Filter: candiesAfterDate', function () {
     var cutoff1 = new Date(2013,11,4);
     var cutoff2 = new Date(2013,11,9);
     expect(candiesAfterDate(candiesSample, cutoff1)).toEqual(candiesSample.slice(2,6));
-    expect(candiesAfterDate(candiesSample, cutoff2)).toEqual(candiesSample.slice(4,6));
+    expect(candiesAfterDate(candiesSample, cutoff2)).toEqual(candiesSample.slice(3,6));
   });
 
 });


### PR DESCRIPTION
enhancements to the candy modal tags input box:
- unify look and feel with remaining of form
- support for custom tags input validation
- new custom tags validation directive with unit tests
- support disabling/enabling Candy Modal Save button based on validation

Closes #12
